### PR TITLE
Hypergraph::quotient returns `Result` instead of panicking.

### DIFF
--- a/examples/polycirc.rs
+++ b/examples/polycirc.rs
@@ -151,7 +151,7 @@ mod imperative {
         state.targets = vec![b];
 
         // build the (strict) open hypergraph
-        state.quotient();
+        state.quotient().unwrap();
         state.to_strict()
     }
 }

--- a/src/lax/open_hypergraph.rs
+++ b/src/lax/open_hypergraph.rs
@@ -231,7 +231,7 @@ impl<O: Clone + PartialEq, A: Clone> OpenHypergraph<O, A> {
     }
 
     /// Deprecated alias for [`Self::quotient`]
-    #[deprecated(since = "0.2.10", note = "use Hypergraph::quotient")]
+    #[deprecated(since = "0.2.10", note = "use OpenHypergraph::quotient")]
     pub fn quotient_witness(&mut self) -> Result<FiniteFunction, FiniteFunction> {
         self.quotient()
     }

--- a/tests/lax/functor.rs
+++ b/tests/lax/functor.rs
@@ -30,13 +30,13 @@ impl<O: PartialEq + Clone, A: Clone + PartialEq> Functor<O, A, O, A> for LaxIden
         } else {
             f_strict = {
                 let mut c = f.clone();
-                c.quotient();
+                c.quotient().unwrap();
                 c
             };
             &f_strict
         };
         let (mut result, _witness) = map_arrow_witness(self, f).unwrap();
-        result.quotient();
+        result.quotient().unwrap();
         result
     }
 }
@@ -112,13 +112,13 @@ impl Functor<(), Arr, (), Arr> for ExpandDefinitions {
         } else {
             f_strict = {
                 let mut c = f.clone();
-                c.quotient();
+                c.quotient().unwrap();
                 c
             };
             &f_strict
         };
         let (mut result, _witness) = map_arrow_witness(self, f).unwrap();
-        result.quotient();
+        result.quotient().unwrap();
         result
     }
 }
@@ -138,7 +138,7 @@ fn test_sub_expand() {
     assert_eq!(witness.sources.table.0, vec![1, 1, 1]);
 
     // Quotient the result, mapping the witness through the coequalizer.
-    let q = result.quotient_witness();
+    let q = result.quotient().unwrap();
     let witness = witness.map_values(&q).unwrap();
 
     // Source/target types are preserved


### PR DESCRIPTION
Until this change, `Hypergraph::quotient` would panic if the quotient map identified nodes with different labels.
This frequently caused crashes in user code, and was bad design.

Now, `Hypergraph::quotient` returns a `Result` where both Ok and Err branches contain the coequalizer computed from the `self.quotient` graph.
In the Ok case however, the underlying Hypergraph also has nodes in each connected component *identified*.
The `Err` case leaves the hypergraph unchanged.