### PR TITLE
move `graph::converse` to new relation module...

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "open-hypergraphs"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Data-Parallel Algorithms for Open Hypergraphs"
 license = "MIT OR Apache-2.0"

--- a/src/finite_function/arrow.rs
+++ b/src/finite_function/arrow.rs
@@ -227,7 +227,7 @@ where
         }
 
         let counts = self.table.bincount(self.target.clone());
-        counts.max().map_or(true, |m| m <= K::I::one())
+        counts.max().is_none_or(|m| m <= K::I::one())
     }
 
     /// Check whether `self` and `other` have disjoint images in a common codomain.

--- a/src/strict/eval.rs
+++ b/src/strict/eval.rs
@@ -5,9 +5,9 @@ use crate::finite_function::*;
 use crate::indexed_coproduct::*;
 use crate::semifinite::*;
 
-use crate::strict::graph::converse;
 use crate::strict::layer::layer;
 use crate::strict::open_hypergraph::*;
+use crate::strict::relation::converse;
 
 use num_traits::Zero;
 use std::default::Default;

--- a/src/strict/graph.rs
+++ b/src/strict/graph.rs
@@ -1,47 +1,10 @@
-use crate::array::{Array, ArrayKind, NaturalArray, OrdArray};
+use super::relation::converse;
+use crate::array::{Array, ArrayKind, NaturalArray};
 use crate::category::Arrow;
 use crate::finite_function::FiniteFunction;
-use crate::indexed_coproduct::HasLen;
 use crate::indexed_coproduct::IndexedCoproduct;
 use crate::strict::hypergraph::Hypergraph;
 use num_traits::{One, Zero};
-
-/// Compute the *converse* of an [`IndexedCoproduct`] thought of as a "multirelation".
-///
-/// An [`IndexedCoproduct`] `c : Σ_{x ∈ X} s(x) → Q` can equivalently be thought of as `c : X →
-/// Q*`, i.e. a mapping from X to finite lists of elements in Q.
-///
-/// Such a list defines a (multi-)relation as the multiset of pairs
-///
-/// `R = { ( x, f(x)_i ) | x ∈ X, i ∈ len(f(x)) }`
-///
-/// This function computes the *converse* of that relation as an indexed coproduct
-/// `converse(c) : Q → X*`, or more precisely
-/// `converse(c) : Σ_{q ∈ Q} s(q) → X`.
-///
-/// NOTE: An indexed coproduct does not uniquely represent a 'multirelation', since *order* of the
-/// elements matters.
-/// The result of this function is only unique up to permutation of the sublists.
-pub(crate) fn converse<K: ArrayKind>(
-    r: &IndexedCoproduct<K, FiniteFunction<K>>,
-) -> IndexedCoproduct<K, FiniteFunction<K>>
-where
-    K::Type<K::I>: NaturalArray<K>,
-{
-    let values_table = {
-        let arange = K::Index::arange(&K::I::zero(), &r.sources.len());
-        let unsorted_values = r.sources.table.repeat(arange.get_range(..));
-        unsorted_values.sort_by(&r.values.table)
-    };
-
-    let sources_table =
-        (r.values.table.as_ref() as &K::Type<K::I>).bincount(r.values.target.clone());
-
-    let sources = FiniteFunction::new(sources_table, r.values.table.len() + K::I::one()).unwrap();
-    let values = FiniteFunction::new(values_table, r.len()).unwrap();
-
-    IndexedCoproduct::new(sources, values).unwrap()
-}
 
 /// Return the adjacency map for a [`Hypergraph`] `h`.
 ///

--- a/src/strict/hypergraph/arrow.rs
+++ b/src/strict/hypergraph/arrow.rs
@@ -230,7 +230,7 @@ where
 
     // If any selected node is reachable in layer 1, it's not convex.
     let reached_selected = visited1.gather(w.table.get_range(..));
-    !reached_selected.max().map_or(false, |m| m >= K::I::one())
+    !reached_selected.max().is_some_and(|m| m >= K::I::one())
 }
 
 impl<K: ArrayKind, O, A> HypergraphArrow<K, O, A>

--- a/src/strict/mod.rs
+++ b/src/strict/mod.rs
@@ -10,6 +10,7 @@ pub mod eval;
 pub mod functor;
 pub mod graph;
 pub mod layer;
+pub mod relation;
 
 pub use crate::array::*;
 pub use crate::category::*;

--- a/src/strict/relation.rs
+++ b/src/strict/relation.rs
@@ -1,0 +1,42 @@
+//! Indexed coproducts as relations
+use crate::array::{Array, ArrayKind, NaturalArray, OrdArray};
+use crate::finite_function::FiniteFunction;
+use crate::indexed_coproduct::{HasLen, IndexedCoproduct};
+use num_traits::{One, Zero};
+
+/// Compute the *converse* of an [`IndexedCoproduct`] thought of as a "multirelation".
+///
+/// An [`IndexedCoproduct`] `c : Σ_{x ∈ X} s(x) → Q` can equivalently be thought of as `c : X →
+/// Q*`, i.e. a mapping from X to finite lists of elements in Q.
+///
+/// Such a list defines a (multi-)relation as the multiset of pairs
+///
+/// `R = { ( x, f(x)_i ) | x ∈ X, i ∈ len(f(x)) }`
+///
+/// This function computes the *converse* of that relation as an indexed coproduct
+/// `converse(c) : Q → X*`, or more precisely
+/// `converse(c) : Σ_{q ∈ Q} s(q) → X`.
+///
+/// NOTE: An indexed coproduct does not uniquely represent a 'multirelation', since *order* of the
+/// elements matters.
+/// The result of this function is only unique up to permutation of the sublists.
+pub fn converse<K: ArrayKind>(
+    r: &IndexedCoproduct<K, FiniteFunction<K>>,
+) -> IndexedCoproduct<K, FiniteFunction<K>>
+where
+    K::Type<K::I>: NaturalArray<K>,
+{
+    let values_table = {
+        let arange = K::Index::arange(&K::I::zero(), &r.sources.len());
+        let unsorted_values = r.sources.table.repeat(arange.get_range(..));
+        unsorted_values.sort_by(&r.values.table)
+    };
+
+    let sources_table =
+        (r.values.table.as_ref() as &K::Type<K::I>).bincount(r.values.target.clone());
+
+    let sources = FiniteFunction::new(sources_table, r.values.table.len() + K::I::one()).unwrap();
+    let values = FiniteFunction::new(values_table, r.len()).unwrap();
+
+    IndexedCoproduct::new(sources, values).unwrap()
+}

--- a/src/strict/tests/layer.rs
+++ b/src/strict/tests/layer.rs
@@ -2,9 +2,10 @@ use crate::array::vec::*;
 use crate::finite_function::*;
 use crate::indexed_coproduct::*;
 use crate::semifinite::*;
-use crate::strict::graph::{converse, indegree, operation_adjacency};
+use crate::strict::graph::{indegree, operation_adjacency};
 use crate::strict::layer::layer;
 use crate::strict::open_hypergraph::*;
+use crate::strict::relation::converse;
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum Arr {


### PR DESCRIPTION
... and make public.

This is a generic method on IndexedCoproducts thought of as encoding relations, and was used in some downstream projects.