### PR TITLE
Ullman V2 subgraph isomorphism

### DIFF
--- a/src/strict/hypergraph/matching.rs
+++ b/src/strict/hypergraph/matching.rs
@@ -10,10 +10,21 @@ use core::convert::TryFrom;
 type EdgeId = usize;
 type NodeId = usize;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct MatchOptions {
+    pub mono: bool,
     pub require_convex: bool,
     pub stop_after_first: bool,
+}
+
+impl Default for MatchOptions {
+    fn default() -> Self {
+        Self {
+            mono: true,
+            require_convex: false,
+            stop_after_first: false,
+        }
+    }
 }
 
 #[derive(Clone, PartialEq)]
@@ -181,7 +192,7 @@ where
     let host_wire_count: usize = host.w.len().into();
     let host_op_count: usize = host.x.len().into();
 
-    if pattern_wire_count > host_wire_count || pattern_op_count > host_op_count {
+    if (options.mono && pattern_wire_count > host_wire_count) || pattern_op_count > host_op_count {
         return Vec::new();
     }
 
@@ -191,7 +202,7 @@ where
     let host_targets = incidence_lists(&host.t);
 
     let initial = SearchState {
-        wire_candidates: CandidateMap::new(initial_wire_candidates(pattern, host)),
+        wire_candidates: CandidateMap::new(initial_wire_candidates(pattern, host, options)),
         op_candidates: CandidateMap::new(initial_op_candidates(
             pattern,
             host,
@@ -247,6 +258,7 @@ fn search<K: ArrayKind, O, A>(
         pattern_targets,
         host_sources,
         host_targets,
+        options,
         &mut state,
     ) {
         return;
@@ -326,7 +338,7 @@ where
         ) => return None,
     }
 
-    if !w.is_injective() || !x.is_injective() {
+    if !x.is_injective() || (options.mono && !w.is_injective()) {
         return None;
     }
 
@@ -360,6 +372,7 @@ fn refine_domains(
     pattern_targets: &OrderedIncidence,
     host_sources: &OrderedIncidence,
     host_targets: &OrderedIncidence,
+    options: &MatchOptions,
     state: &mut SearchState,
 ) -> bool {
     loop {
@@ -370,10 +383,14 @@ fn refine_domains(
         }
 
         let mut changed = false;
-        // Once a pattern item has a unique host candidate, injectivity forces
-        // that host item to disappear from every other non-singleton row.
-        changed |= state.wire_candidates.enforce_injective_singletons();
+        // Edge matches remain injective even when wire matches are allowed to
+        // fold, so singleton edge columns are always removed elsewhere.
         changed |= state.op_candidates.enforce_injective_singletons();
+        if options.mono {
+            // When wire matches are monic, singleton wire columns can also be
+            // removed from every other non-singleton row.
+            changed |= state.wire_candidates.enforce_injective_singletons();
+        }
 
         if state.wire_candidates.has_empty_row() || state.op_candidates.has_empty_row() {
             return false;
@@ -542,6 +559,7 @@ where
 fn initial_wire_candidates<K: ArrayKind, O, A>(
     pattern: &Hypergraph<K, O, A>,
     host: &Hypergraph<K, O, A>,
+    options: &MatchOptions,
 ) -> Vec<Vec<bool>>
 where
     K::Type<K::I>: NaturalArray<K>,
@@ -567,8 +585,9 @@ where
                         .ok()
                         .expect("host wire index conversion failed");
                     pattern_label == host.w.0.get(host_wire_ix.clone())
-                        && pattern_in_degree <= host.in_degree(host_wire_ix.clone())
-                        && pattern_out_degree <= host.out_degree(host_wire_ix)
+                        && (!options.mono
+                            || (pattern_in_degree <= host.in_degree(host_wire_ix.clone())
+                                && pattern_out_degree <= host.out_degree(host_wire_ix)))
                 })
                 .collect()
         })

--- a/src/strict/hypergraph/matching.rs
+++ b/src/strict/hypergraph/matching.rs
@@ -305,8 +305,14 @@ where
     let w_table = state.wire_candidates.singleton_assignment_table::<K>()?;
     let x_table = state.op_candidates.singleton_assignment_table::<K>()?;
 
-    let w = FiniteFunction::new(K::Index::from_slice(K::Slice::from(w_table.as_slice())), host.w.len())?;
-    let x = FiniteFunction::new(K::Index::from_slice(K::Slice::from(x_table.as_slice())), host.x.len())?;
+    let w = FiniteFunction::new(
+        K::Index::from_slice(K::Slice::from(w_table.as_slice())),
+        host.w.len(),
+    )?;
+    let x = FiniteFunction::new(
+        K::Index::from_slice(K::Slice::from(x_table.as_slice())),
+        host.x.len(),
+    )?;
 
     match validate_hypergraph_morphism(pattern, host, &w, &x) {
         Ok(()) => {}
@@ -590,14 +596,16 @@ where
 
     (0..pattern_op_count)
         .map(|pattern_op| {
-            let pattern_op_ix =
-                K::I::try_from(pattern_op).ok().expect("pattern op index conversion failed");
+            let pattern_op_ix = K::I::try_from(pattern_op)
+                .ok()
+                .expect("pattern op index conversion failed");
             let pattern_label = pattern.x.0.get(pattern_op_ix);
 
             (0..host_op_count)
                 .map(|host_op| {
-                    let host_op_ix =
-                        K::I::try_from(host_op).ok().expect("host op index conversion failed");
+                    let host_op_ix = K::I::try_from(host_op)
+                        .ok()
+                        .expect("host op index conversion failed");
                     let same_label = pattern_label == host.x.0.get(host_op_ix);
                     let same_arity = pattern_sources.edge(pattern_op).len()
                         == host_sources.edge(host_op).len()
@@ -639,8 +647,9 @@ where
         .iter()
         .zip(host_wires.iter())
         .all(|(&pattern_wire, &host_wire)| {
-            let pattern_ix =
-                K::I::try_from(pattern_wire).ok().expect("pattern endpoint conversion failed");
+            let pattern_ix = K::I::try_from(pattern_wire)
+                .ok()
+                .expect("pattern endpoint conversion failed");
             let host_ix = K::I::try_from(host_wire)
                 .ok()
                 .expect("host endpoint conversion failed");

--- a/src/strict/hypergraph/matching.rs
+++ b/src/strict/hypergraph/matching.rs
@@ -1,0 +1,649 @@
+use crate::array::{Array, ArrayKind, NaturalArray};
+use crate::finite_function::FiniteFunction;
+use crate::strict::hypergraph::arrow::{
+    is_convex_subgraph_morphism, validate_hypergraph_morphism, InvalidHypergraphArrow,
+};
+use crate::strict::hypergraph::Hypergraph;
+
+use core::convert::TryFrom;
+
+type EdgeId = usize;
+type NodeId = usize;
+
+#[derive(Clone, Debug, Default)]
+pub struct MatchOptions {
+    pub require_convex: bool,
+    pub stop_after_first: bool,
+}
+
+#[derive(Clone, PartialEq)]
+pub struct HypergraphMatch<K: ArrayKind> {
+    pub w: FiniteFunction<K>,
+    pub x: FiniteFunction<K>,
+}
+
+#[derive(Clone)]
+struct SearchState {
+    wire_candidates: CandidateMap,
+    op_candidates: CandidateMap,
+}
+
+#[derive(Clone)]
+struct OrderedIncidence {
+    by_edge: Vec<Vec<NodeId>>,
+}
+
+impl OrderedIncidence {
+    fn edge(&self, edge: EdgeId) -> &[NodeId] {
+        &self.by_edge[edge]
+    }
+
+    fn edge_count(&self) -> EdgeId {
+        self.by_edge.len()
+    }
+}
+
+#[derive(Clone)]
+struct CandidateMap {
+    by_pattern: Vec<Vec<bool>>,
+}
+
+impl CandidateMap {
+    fn new(by_pattern: Vec<Vec<bool>>) -> Self {
+        Self { by_pattern }
+    }
+
+    fn row(&self, pattern_id: usize) -> &[bool] {
+        &self.by_pattern[pattern_id]
+    }
+
+    fn row_mut(&mut self, pattern_id: usize) -> &mut [bool] {
+        &mut self.by_pattern[pattern_id]
+    }
+
+    fn pattern_count(&self) -> usize {
+        self.by_pattern.len()
+    }
+
+    fn host_count(&self, pattern_id: usize) -> usize {
+        self.by_pattern[pattern_id].len()
+    }
+
+    fn allows(&self, pattern_id: usize, host_id: usize) -> bool {
+        self.by_pattern[pattern_id][host_id]
+    }
+
+    fn remove(&mut self, pattern_id: usize, host_id: usize) {
+        self.by_pattern[pattern_id][host_id] = false;
+    }
+
+    fn retain_only(&mut self, pattern_id: usize, host_id: usize) {
+        let row = self.row_mut(pattern_id);
+        for allowed in row.iter_mut() {
+            *allowed = false;
+        }
+        row[host_id] = true;
+    }
+
+    fn has_empty_row(&self) -> bool {
+        self.by_pattern
+            .iter()
+            .any(|row| row.iter().all(|allowed| !allowed))
+    }
+
+    fn singleton_assignment_table<K: ArrayKind>(&self) -> Option<Vec<K::I>>
+    where
+        K::I: TryFrom<usize>,
+    {
+        let mut out = Vec::with_capacity(self.by_pattern.len());
+        for row in &self.by_pattern {
+            let mut candidate = None;
+            for (ix, allowed) in row.iter().enumerate() {
+                if *allowed {
+                    if candidate.is_some() {
+                        return None;
+                    }
+                    candidate = Some(ix);
+                }
+            }
+            let ix = candidate?;
+            out.push(K::I::try_from(ix).ok()?);
+        }
+        Some(out)
+    }
+
+    fn best_nontrivial_row(&self) -> Option<(usize, Vec<usize>)> {
+        let mut best: Option<(usize, Vec<usize>)> = None;
+        for (pattern_id, row) in self.by_pattern.iter().enumerate() {
+            let candidates = allowed_indices(row);
+            if candidates.len() <= 1 {
+                continue;
+            }
+            let replace = best
+                .as_ref()
+                .is_none_or(|(_, current)| candidates.len() < current.len());
+            if replace {
+                best = Some((pattern_id, candidates));
+            }
+        }
+        best
+    }
+
+    fn enforce_injective_singletons(&mut self) -> bool {
+        let singleton_columns: Vec<_> = self
+            .by_pattern
+            .iter()
+            .filter_map(|row| {
+                let allowed = allowed_indices(row);
+                if allowed.len() == 1 {
+                    Some(allowed[0])
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let mut changed = false;
+        for row in &mut self.by_pattern {
+            let allowed = allowed_indices(row);
+            if allowed.len() == 1 {
+                continue;
+            }
+
+            for &column in &singleton_columns {
+                if row[column] {
+                    row[column] = false;
+                    changed = true;
+                }
+            }
+        }
+
+        changed
+    }
+}
+
+pub fn find_subgraph_matches<K: ArrayKind, O, A>(
+    pattern: &Hypergraph<K, O, A>,
+    host: &Hypergraph<K, O, A>,
+    options: &MatchOptions,
+) -> Vec<HypergraphMatch<K>>
+where
+    K::Type<K::I>: NaturalArray<K>,
+    K::Type<O>: Array<K, O> + PartialEq,
+    K::Type<A>: Array<K, A> + PartialEq,
+    O: PartialEq,
+    A: PartialEq,
+    K::I: Into<usize> + TryFrom<usize>,
+    for<'a> K::Slice<'a, K::I>: From<&'a [K::I]>,
+{
+    let pattern_wire_count: usize = pattern.w.len().into();
+    let pattern_op_count: usize = pattern.x.len().into();
+    let host_wire_count: usize = host.w.len().into();
+    let host_op_count: usize = host.x.len().into();
+
+    if pattern_wire_count > host_wire_count || pattern_op_count > host_op_count {
+        return Vec::new();
+    }
+
+    let pattern_sources = incidence_lists(&pattern.s);
+    let pattern_targets = incidence_lists(&pattern.t);
+    let host_sources = incidence_lists(&host.s);
+    let host_targets = incidence_lists(&host.t);
+
+    let initial = SearchState {
+        wire_candidates: CandidateMap::new(initial_wire_candidates(pattern, host)),
+        op_candidates: CandidateMap::new(initial_op_candidates(
+            pattern,
+            host,
+            &pattern_sources,
+            &pattern_targets,
+            &host_sources,
+            &host_targets,
+        )),
+    };
+
+    let mut matches = Vec::new();
+    search(
+        pattern,
+        host,
+        &pattern_sources,
+        &pattern_targets,
+        &host_sources,
+        &host_targets,
+        options,
+        initial,
+        &mut matches,
+    );
+    matches
+}
+
+// This implements an Ullmann-style subgraph search specialized to strict
+// directed hypergraphs with ordered source/target ports:
+// 1. Build initial candidate maps for wires and operations from cheap local tests.
+// 2. Refine those candidates to a fixpoint using incidence consistency between
+//    wire candidates and operation candidates.
+// 3. Branch on the smallest remaining non-singleton candidate row and recurse.
+// 4. Validate each singleton assignment with the existing hypergraph morphism
+//    predicates, optionally requiring convexity.
+fn search<K: ArrayKind, O, A>(
+    pattern: &Hypergraph<K, O, A>,
+    host: &Hypergraph<K, O, A>,
+    pattern_sources: &OrderedIncidence,
+    pattern_targets: &OrderedIncidence,
+    host_sources: &OrderedIncidence,
+    host_targets: &OrderedIncidence,
+    options: &MatchOptions,
+    mut state: SearchState,
+    matches: &mut Vec<HypergraphMatch<K>>,
+) where
+    K::Type<K::I>: NaturalArray<K>,
+    K::Type<O>: Array<K, O> + PartialEq,
+    K::Type<A>: Array<K, A> + PartialEq,
+    K::I: Into<usize> + TryFrom<usize>,
+    for<'a> K::Slice<'a, K::I>: From<&'a [K::I]>,
+{
+    if !refine_domains(
+        pattern_sources,
+        pattern_targets,
+        host_sources,
+        host_targets,
+        &mut state,
+    ) {
+        return;
+    }
+
+    if let Some(m) = build_match(pattern, host, options, &state) {
+        matches.push(m);
+        return;
+    }
+
+    let choice = pick_branch_row(&state);
+    let Some((branch_on_ops, row, candidates)) = choice else {
+        return;
+    };
+
+    for candidate in candidates {
+        if options.stop_after_first && !matches.is_empty() {
+            return;
+        }
+
+        let mut next = state.clone();
+        let candidates = if branch_on_ops {
+            &mut next.op_candidates
+        } else {
+            &mut next.wire_candidates
+        };
+        candidates.retain_only(row, candidate);
+
+        search(
+            pattern,
+            host,
+            pattern_sources,
+            pattern_targets,
+            host_sources,
+            host_targets,
+            options,
+            next,
+            matches,
+        );
+    }
+}
+
+fn build_match<K: ArrayKind, O, A>(
+    pattern: &Hypergraph<K, O, A>,
+    host: &Hypergraph<K, O, A>,
+    options: &MatchOptions,
+    state: &SearchState,
+) -> Option<HypergraphMatch<K>>
+where
+    K::Type<K::I>: NaturalArray<K>,
+    K::Type<O>: Array<K, O> + PartialEq,
+    K::Type<A>: Array<K, A> + PartialEq,
+    K::I: Into<usize> + TryFrom<usize>,
+    for<'a> K::Slice<'a, K::I>: From<&'a [K::I]>,
+{
+    let w_table = state.wire_candidates.singleton_assignment_table::<K>()?;
+    let x_table = state.op_candidates.singleton_assignment_table::<K>()?;
+
+    let w = FiniteFunction::new(K::Index::from_slice(K::Slice::from(w_table.as_slice())), host.w.len())?;
+    let x = FiniteFunction::new(K::Index::from_slice(K::Slice::from(x_table.as_slice())), host.x.len())?;
+
+    match validate_hypergraph_morphism(pattern, host, &w, &x) {
+        Ok(()) => {}
+        Err(
+            InvalidHypergraphArrow::TypeMismatchW
+            | InvalidHypergraphArrow::TypeMismatchX
+            | InvalidHypergraphArrow::NotNaturalW
+            | InvalidHypergraphArrow::NotNaturalX
+            | InvalidHypergraphArrow::NotNaturalS
+            | InvalidHypergraphArrow::NotNaturalT,
+        ) => return None,
+    }
+
+    if !w.is_injective() || !x.is_injective() {
+        return None;
+    }
+
+    if options.require_convex && !is_convex_subgraph_morphism(pattern, host, &w, &x) {
+        return None;
+    }
+
+    Some(HypergraphMatch { w, x })
+}
+
+fn pick_branch_row(state: &SearchState) -> Option<(bool, usize, Vec<usize>)> {
+    let op_choice = state.op_candidates.best_nontrivial_row();
+    let wire_choice = state.wire_candidates.best_nontrivial_row();
+
+    match (op_choice, wire_choice) {
+        (Some((op_row, op_candidates)), Some((wire_row, wire_candidates))) => {
+            if op_candidates.len() <= wire_candidates.len() {
+                Some((true, op_row, op_candidates))
+            } else {
+                Some((false, wire_row, wire_candidates))
+            }
+        }
+        (Some((op_row, op_candidates)), None) => Some((true, op_row, op_candidates)),
+        (None, Some((wire_row, wire_candidates))) => Some((false, wire_row, wire_candidates)),
+        (None, None) => None,
+    }
+}
+
+fn refine_domains(
+    pattern_sources: &OrderedIncidence,
+    pattern_targets: &OrderedIncidence,
+    host_sources: &OrderedIncidence,
+    host_targets: &OrderedIncidence,
+    state: &mut SearchState,
+) -> bool {
+    loop {
+        // Any empty candidate row means the partial match is inconsistent:
+        // some pattern wire/op has no possible image left in the host.
+        if state.wire_candidates.has_empty_row() || state.op_candidates.has_empty_row() {
+            return false;
+        }
+
+        let mut changed = false;
+        // Once a pattern item has a unique host candidate, injectivity forces
+        // that host item to disappear from every other non-singleton row.
+        changed |= state.wire_candidates.enforce_injective_singletons();
+        changed |= state.op_candidates.enforce_injective_singletons();
+
+        if state.wire_candidates.has_empty_row() || state.op_candidates.has_empty_row() {
+            return false;
+        }
+
+        // Alternate between edge-level and wire-level consistency checks until
+        // no candidate set changes. This is the Ullmann-style refinement step.
+        changed |= prune_op_candidates(
+            pattern_sources,
+            pattern_targets,
+            host_sources,
+            host_targets,
+            &state.wire_candidates,
+            &mut state.op_candidates,
+        );
+        changed |= prune_wire_candidates(
+            pattern_sources,
+            pattern_targets,
+            host_sources,
+            host_targets,
+            &state.op_candidates,
+            &mut state.wire_candidates,
+        );
+
+        if state.wire_candidates.has_empty_row() || state.op_candidates.has_empty_row() {
+            return false;
+        }
+
+        if !changed {
+            return true;
+        }
+    }
+}
+
+fn prune_op_candidates(
+    pattern_sources: &OrderedIncidence,
+    pattern_targets: &OrderedIncidence,
+    host_sources: &OrderedIncidence,
+    host_targets: &OrderedIncidence,
+    wire_candidates: &CandidateMap,
+    op_candidates: &mut CandidateMap,
+) -> bool {
+    let mut changed = false;
+
+    for pattern_op in 0..op_candidates.pattern_count() {
+        for host_op in 0..op_candidates.host_count(pattern_op) {
+            if !op_candidates.allows(pattern_op, host_op) {
+                continue;
+            }
+
+            // A candidate edge match survives only if each source/target port
+            // of the pattern edge can still land on the corresponding port of
+            // the host edge via the current wire candidate map.
+            let src_ok = pattern_sources
+                .edge(pattern_op)
+                .iter()
+                .zip(host_sources.edge(host_op).iter())
+                .all(|(&pattern_wire, &host_wire)| wire_candidates.allows(pattern_wire, host_wire));
+            let tgt_ok = pattern_targets
+                .edge(pattern_op)
+                .iter()
+                .zip(host_targets.edge(host_op).iter())
+                .all(|(&pattern_wire, &host_wire)| wire_candidates.allows(pattern_wire, host_wire));
+
+            if !(src_ok && tgt_ok) {
+                op_candidates.remove(pattern_op, host_op);
+                changed = true;
+            }
+        }
+    }
+
+    changed
+}
+
+fn prune_wire_candidates(
+    pattern_sources: &OrderedIncidence,
+    pattern_targets: &OrderedIncidence,
+    host_sources: &OrderedIncidence,
+    host_targets: &OrderedIncidence,
+    op_candidates: &CandidateMap,
+    wire_candidates: &mut CandidateMap,
+) -> bool {
+    let mut changed = false;
+
+    for pattern_wire in 0..wire_candidates.pattern_count() {
+        for host_wire in 0..wire_candidates.host_count(pattern_wire) {
+            if !wire_candidates.allows(pattern_wire, host_wire) {
+                continue;
+            }
+
+            // A candidate wire match survives only if every occurrence of the
+            // pattern wire as an input/output port is supported by at least one
+            // still-allowed candidate edge match at that same port position.
+            let src_ok = (0..pattern_sources.edge_count()).all(|pattern_op| {
+                pattern_sources
+                    .edge(pattern_op)
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, w)| **w == pattern_wire)
+                    .all(|(position, _)| {
+                        op_candidates.row(pattern_op).iter().enumerate().any(
+                            |(host_op, allowed)| {
+                                *allowed && host_sources.edge(host_op)[position] == host_wire
+                            },
+                        )
+                    })
+            });
+
+            let tgt_ok = (0..pattern_targets.edge_count()).all(|pattern_op| {
+                pattern_targets
+                    .edge(pattern_op)
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, w)| **w == pattern_wire)
+                    .all(|(position, _)| {
+                        op_candidates.row(pattern_op).iter().enumerate().any(
+                            |(host_op, allowed)| {
+                                *allowed && host_targets.edge(host_op)[position] == host_wire
+                            },
+                        )
+                    })
+            });
+
+            if !(src_ok && tgt_ok) {
+                wire_candidates.remove(pattern_wire, host_wire);
+                changed = true;
+            }
+        }
+    }
+
+    changed
+}
+
+fn allowed_indices(domain: &[bool]) -> Vec<usize> {
+    domain
+        .iter()
+        .enumerate()
+        .filter_map(|(ix, allowed)| allowed.then_some(ix))
+        .collect()
+}
+
+fn incidence_lists<K: ArrayKind>(
+    incidence: &crate::indexed_coproduct::IndexedCoproduct<K, FiniteFunction<K>>,
+) -> OrderedIncidence
+where
+    K::Type<K::I>: NaturalArray<K>,
+    K::I: Into<usize> + TryFrom<usize>,
+{
+    OrderedIncidence {
+        by_edge: incidence
+            .clone()
+            .into_iter()
+            .map(|f| {
+                (0..f.table.len().into())
+                    .map(|ix| {
+                        f.table
+                            .get(K::I::try_from(ix).ok().expect("index conversion failed"))
+                            .into()
+                    })
+                    .collect()
+            })
+            .collect(),
+    }
+}
+
+fn initial_wire_candidates<K: ArrayKind, O, A>(
+    pattern: &Hypergraph<K, O, A>,
+    host: &Hypergraph<K, O, A>,
+) -> Vec<Vec<bool>>
+where
+    K::Type<K::I>: NaturalArray<K>,
+    K::Type<O>: Array<K, O> + PartialEq,
+    O: PartialEq,
+    K::I: Into<usize> + TryFrom<usize>,
+{
+    let pattern_wire_count: usize = pattern.w.len().into();
+    let host_wire_count: usize = host.w.len().into();
+
+    (0..pattern_wire_count)
+        .map(|pattern_wire| {
+            let pattern_wire_ix = K::I::try_from(pattern_wire)
+                .ok()
+                .expect("pattern wire index conversion failed");
+            let pattern_label = pattern.w.0.get(pattern_wire_ix.clone());
+            let pattern_in_degree = pattern.in_degree(pattern_wire_ix.clone());
+            let pattern_out_degree = pattern.out_degree(pattern_wire_ix);
+
+            (0..host_wire_count)
+                .map(|host_wire| {
+                    let host_wire_ix = K::I::try_from(host_wire)
+                        .ok()
+                        .expect("host wire index conversion failed");
+                    pattern_label == host.w.0.get(host_wire_ix.clone())
+                        && pattern_in_degree <= host.in_degree(host_wire_ix.clone())
+                        && pattern_out_degree <= host.out_degree(host_wire_ix)
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn initial_op_candidates<K: ArrayKind, O, A>(
+    pattern: &Hypergraph<K, O, A>,
+    host: &Hypergraph<K, O, A>,
+    pattern_sources: &OrderedIncidence,
+    pattern_targets: &OrderedIncidence,
+    host_sources: &OrderedIncidence,
+    host_targets: &OrderedIncidence,
+) -> Vec<Vec<bool>>
+where
+    K::Type<K::I>: NaturalArray<K>,
+    K::Type<O>: Array<K, O> + PartialEq,
+    K::Type<A>: Array<K, A> + PartialEq,
+    O: PartialEq,
+    A: PartialEq,
+    K::I: Into<usize> + TryFrom<usize>,
+{
+    let pattern_op_count: usize = pattern.x.len().into();
+    let host_op_count: usize = host.x.len().into();
+
+    (0..pattern_op_count)
+        .map(|pattern_op| {
+            let pattern_op_ix =
+                K::I::try_from(pattern_op).ok().expect("pattern op index conversion failed");
+            let pattern_label = pattern.x.0.get(pattern_op_ix);
+
+            (0..host_op_count)
+                .map(|host_op| {
+                    let host_op_ix =
+                        K::I::try_from(host_op).ok().expect("host op index conversion failed");
+                    let same_label = pattern_label == host.x.0.get(host_op_ix);
+                    let same_arity = pattern_sources.edge(pattern_op).len()
+                        == host_sources.edge(host_op).len()
+                        && pattern_targets.edge(pattern_op).len()
+                            == host_targets.edge(host_op).len();
+
+                    same_label
+                        && same_arity
+                        && endpoints_have_matching_labels(
+                            pattern,
+                            host,
+                            pattern_sources.edge(pattern_op),
+                            host_sources.edge(host_op),
+                        )
+                        && endpoints_have_matching_labels(
+                            pattern,
+                            host,
+                            pattern_targets.edge(pattern_op),
+                            host_targets.edge(host_op),
+                        )
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn endpoints_have_matching_labels<K: ArrayKind, O, A>(
+    pattern: &Hypergraph<K, O, A>,
+    host: &Hypergraph<K, O, A>,
+    pattern_wires: &[usize],
+    host_wires: &[usize],
+) -> bool
+where
+    K::Type<O>: Array<K, O> + PartialEq,
+    O: PartialEq,
+    K::I: TryFrom<usize>,
+{
+    pattern_wires
+        .iter()
+        .zip(host_wires.iter())
+        .all(|(&pattern_wire, &host_wire)| {
+            let pattern_ix =
+                K::I::try_from(pattern_wire).ok().expect("pattern endpoint conversion failed");
+            let host_ix = K::I::try_from(host_wire)
+                .ok()
+                .expect("host endpoint conversion failed");
+            pattern.w.0.get(pattern_ix) == host.w.0.get(host_ix)
+        })
+}

--- a/src/strict/hypergraph/matching.rs
+++ b/src/strict/hypergraph/matching.rs
@@ -12,7 +12,7 @@ type NodeId = usize;
 
 #[derive(Clone, Debug)]
 pub struct MatchOptions {
-    pub mono: bool,
+    pub non_mono_wires: Vec<usize>,
     pub require_convex: bool,
     pub stop_after_first: bool,
 }
@@ -20,10 +20,38 @@ pub struct MatchOptions {
 impl Default for MatchOptions {
     fn default() -> Self {
         Self {
-            mono: true,
+            non_mono_wires: Vec::new(),
             require_convex: false,
             stop_after_first: false,
         }
+    }
+}
+
+#[derive(Clone)]
+struct WireInjectivity {
+    allow_non_mono: Vec<bool>,
+}
+
+impl WireInjectivity {
+    fn from_options(pattern_wire_count: usize, options: &MatchOptions) -> Self {
+        let mut allow_non_mono = vec![false; pattern_wire_count];
+        for &wire in &options.non_mono_wires {
+            if wire < pattern_wire_count {
+                allow_non_mono[wire] = true;
+            }
+        }
+        Self { allow_non_mono }
+    }
+
+    fn requires_injective_image(&self, pattern_wire: usize) -> bool {
+        !self.allow_non_mono[pattern_wire]
+    }
+
+    fn injective_wire_count(&self) -> usize {
+        self.allow_non_mono
+            .iter()
+            .filter(|allowed| !**allowed)
+            .count()
     }
 }
 
@@ -140,11 +168,15 @@ impl CandidateMap {
         best
     }
 
-    fn enforce_injective_singletons(&mut self) -> bool {
+    fn enforce_injective_singletons(&mut self, singleton_rows_are_injective: &[bool]) -> bool {
         let singleton_columns: Vec<_> = self
             .by_pattern
             .iter()
-            .filter_map(|row| {
+            .enumerate()
+            .filter_map(|(pattern_id, row)| {
+                if !singleton_rows_are_injective[pattern_id] {
+                    return None;
+                }
                 let allowed = allowed_indices(row);
                 if allowed.len() == 1 {
                     Some(allowed[0])
@@ -191,8 +223,10 @@ where
     let pattern_op_count: usize = pattern.x.len().into();
     let host_wire_count: usize = host.w.len().into();
     let host_op_count: usize = host.x.len().into();
+    let wire_injectivity = WireInjectivity::from_options(pattern_wire_count, options);
 
-    if (options.mono && pattern_wire_count > host_wire_count) || pattern_op_count > host_op_count {
+    if wire_injectivity.injective_wire_count() > host_wire_count || pattern_op_count > host_op_count
+    {
         return Vec::new();
     }
 
@@ -202,7 +236,11 @@ where
     let host_targets = incidence_lists(&host.t);
 
     let initial = SearchState {
-        wire_candidates: CandidateMap::new(initial_wire_candidates(pattern, host, options)),
+        wire_candidates: CandidateMap::new(initial_wire_candidates(
+            pattern,
+            host,
+            &wire_injectivity,
+        )),
         op_candidates: CandidateMap::new(initial_op_candidates(
             pattern,
             host,
@@ -221,6 +259,7 @@ where
         &pattern_targets,
         &host_sources,
         &host_targets,
+        &wire_injectivity,
         options,
         initial,
         &mut matches,
@@ -243,6 +282,7 @@ fn search<K: ArrayKind, O, A>(
     pattern_targets: &OrderedIncidence,
     host_sources: &OrderedIncidence,
     host_targets: &OrderedIncidence,
+    wire_injectivity: &WireInjectivity,
     options: &MatchOptions,
     mut state: SearchState,
     matches: &mut Vec<HypergraphMatch<K>>,
@@ -258,13 +298,14 @@ fn search<K: ArrayKind, O, A>(
         pattern_targets,
         host_sources,
         host_targets,
+        wire_injectivity,
         options,
         &mut state,
     ) {
         return;
     }
 
-    if let Some(m) = build_match(pattern, host, options, &state) {
+    if let Some(m) = build_match(pattern, host, wire_injectivity, options, &state) {
         matches.push(m);
         return;
     }
@@ -294,6 +335,7 @@ fn search<K: ArrayKind, O, A>(
             pattern_targets,
             host_sources,
             host_targets,
+            wire_injectivity,
             options,
             next,
             matches,
@@ -304,6 +346,7 @@ fn search<K: ArrayKind, O, A>(
 fn build_match<K: ArrayKind, O, A>(
     pattern: &Hypergraph<K, O, A>,
     host: &Hypergraph<K, O, A>,
+    wire_injectivity: &WireInjectivity,
     options: &MatchOptions,
     state: &SearchState,
 ) -> Option<HypergraphMatch<K>>
@@ -338,7 +381,7 @@ where
         ) => return None,
     }
 
-    if !x.is_injective() || (options.mono && !w.is_injective()) {
+    if !x.is_injective() || !wires_are_injective_where_required::<K>(&w, wire_injectivity) {
         return None;
     }
 
@@ -372,7 +415,8 @@ fn refine_domains(
     pattern_targets: &OrderedIncidence,
     host_sources: &OrderedIncidence,
     host_targets: &OrderedIncidence,
-    options: &MatchOptions,
+    wire_injectivity: &WireInjectivity,
+    _options: &MatchOptions,
     state: &mut SearchState,
 ) -> bool {
     loop {
@@ -385,12 +429,17 @@ fn refine_domains(
         let mut changed = false;
         // Edge matches remain injective even when wire matches are allowed to
         // fold, so singleton edge columns are always removed elsewhere.
-        changed |= state.op_candidates.enforce_injective_singletons();
-        if options.mono {
-            // When wire matches are monic, singleton wire columns can also be
-            // removed from every other non-singleton row.
-            changed |= state.wire_candidates.enforce_injective_singletons();
-        }
+        let op_rows_are_injective = vec![true; state.op_candidates.pattern_count()];
+        changed |= state
+            .op_candidates
+            .enforce_injective_singletons(&op_rows_are_injective);
+
+        let wire_rows_are_injective: Vec<_> = (0..state.wire_candidates.pattern_count())
+            .map(|pattern_wire| wire_injectivity.requires_injective_image(pattern_wire))
+            .collect();
+        changed |= state
+            .wire_candidates
+            .enforce_injective_singletons(&wire_rows_are_injective);
 
         if state.wire_candidates.has_empty_row() || state.op_candidates.has_empty_row() {
             return false;
@@ -559,7 +608,7 @@ where
 fn initial_wire_candidates<K: ArrayKind, O, A>(
     pattern: &Hypergraph<K, O, A>,
     host: &Hypergraph<K, O, A>,
-    options: &MatchOptions,
+    wire_injectivity: &WireInjectivity,
 ) -> Vec<Vec<bool>>
 where
     K::Type<K::I>: NaturalArray<K>,
@@ -585,13 +634,44 @@ where
                         .ok()
                         .expect("host wire index conversion failed");
                     pattern_label == host.w.0.get(host_wire_ix.clone())
-                        && (!options.mono
+                        && (!wire_injectivity.requires_injective_image(pattern_wire)
                             || (pattern_in_degree <= host.in_degree(host_wire_ix.clone())
                                 && pattern_out_degree <= host.out_degree(host_wire_ix)))
                 })
                 .collect()
         })
         .collect()
+}
+
+fn wires_are_injective_where_required<K: ArrayKind>(
+    w: &FiniteFunction<K>,
+    wire_injectivity: &WireInjectivity,
+) -> bool
+where
+    K::I: Into<usize> + TryFrom<usize>,
+{
+    let mut image_counts = std::collections::HashMap::<usize, usize>::new();
+    for pattern_wire in 0..wire_injectivity.allow_non_mono.len() {
+        let pattern_wire_ix = K::I::try_from(pattern_wire)
+            .ok()
+            .expect("pattern wire index conversion failed");
+        let host_wire: usize = w.table.get(pattern_wire_ix).into();
+        *image_counts.entry(host_wire).or_insert(0) += 1;
+    }
+
+    for pattern_wire in 0..wire_injectivity.allow_non_mono.len() {
+        if !wire_injectivity.requires_injective_image(pattern_wire) {
+            continue;
+        }
+        let pattern_wire_ix = K::I::try_from(pattern_wire)
+            .ok()
+            .expect("pattern wire index conversion failed");
+        let host_wire: usize = w.table.get(pattern_wire_ix).into();
+        if image_counts.get(&host_wire).copied().unwrap_or(0) > 1 {
+            return false;
+        }
+    }
+    true
 }
 
 fn initial_op_candidates<K: ArrayKind, O, A>(

--- a/src/strict/hypergraph/mod.rs
+++ b/src/strict/hypergraph/mod.rs
@@ -2,6 +2,7 @@
 //! and arrows by [`arrow::HypergraphArrow`].
 mod acyclic;
 pub mod arrow;
+pub mod matching;
 mod object;
 
 pub use object::*;

--- a/src/strict/hypergraph/mod.rs
+++ b/src/strict/hypergraph/mod.rs
@@ -2,6 +2,7 @@
 //! and arrows by [`arrow::HypergraphArrow`].
 mod acyclic;
 pub mod arrow;
+#[cfg(any(feature = "experimental", test))]
 pub mod matching;
 mod object;
 

--- a/src/strict/open_hypergraph/matching.rs
+++ b/src/strict/open_hypergraph/matching.rs
@@ -27,6 +27,27 @@ impl<K: ArrayKind> OpenHypergraphMatch<K> {
     }
 }
 
+fn options_with_interface_wires_relaxed<K: ArrayKind, O, A>(
+    pattern: &OpenHypergraph<K, O, A>,
+    options: &MatchOptions,
+) -> MatchOptions
+where
+    K::I: Into<usize> + core::convert::TryFrom<usize>,
+{
+    let mut derived = options.clone();
+    for boundary in [&pattern.s, &pattern.t] {
+        let boundary_len: usize = boundary.table.len().into();
+        for boundary_ix in 0..boundary_len {
+            let boundary_ix = K::I::try_from(boundary_ix)
+                .ok()
+                .expect("boundary index conversion failed");
+            let wire_ix: usize = boundary.table.get(boundary_ix).into();
+            derived.non_mono_wires.push(wire_ix);
+        }
+    }
+    derived
+}
+
 pub(crate) fn smc_boundary_images<K: ArrayKind, O, A>(
     pattern: &OpenHypergraph<K, O, A>,
     w: &FiniteFunction<K>,
@@ -71,7 +92,8 @@ where
     K::I: Into<usize> + core::convert::TryFrom<usize>,
     for<'a> K::Slice<'a, K::I>: From<&'a [K::I]>,
 {
-    find_hypergraph_subgraph_matches(&pattern.h, &host.h, options)
+    let derived_options = options_with_interface_wires_relaxed(pattern, options);
+    find_hypergraph_subgraph_matches(&pattern.h, &host.h, &derived_options)
         .into_iter()
         .map(|HypergraphMatch { w, x }| OpenHypergraphMatch { w, x })
         .collect()

--- a/src/strict/open_hypergraph/matching.rs
+++ b/src/strict/open_hypergraph/matching.rs
@@ -1,0 +1,98 @@
+use crate::array::{Array, ArrayKind, NaturalArray};
+use crate::finite_function::FiniteFunction;
+use crate::strict::hypergraph::matching::{
+    find_subgraph_matches as find_hypergraph_subgraph_matches, HypergraphMatch, MatchOptions,
+};
+use crate::strict::open_hypergraph::OpenHypergraph;
+
+#[derive(Clone, PartialEq)]
+pub struct OpenHypergraphMatch<K: ArrayKind> {
+    pub w: crate::finite_function::FiniteFunction<K>,
+    pub x: crate::finite_function::FiniteFunction<K>,
+}
+
+impl<K: ArrayKind> OpenHypergraphMatch<K> {
+    pub fn source_image<O, A>(
+        &self,
+        pattern: &OpenHypergraph<K, O, A>,
+    ) -> Option<crate::finite_function::FiniteFunction<K>> {
+        &pattern.s >> &self.w
+    }
+
+    pub fn target_image<O, A>(
+        &self,
+        pattern: &OpenHypergraph<K, O, A>,
+    ) -> Option<crate::finite_function::FiniteFunction<K>> {
+        &pattern.t >> &self.w
+    }
+}
+
+pub(crate) fn smc_boundary_images<K: ArrayKind, O, A>(
+    pattern: &OpenHypergraph<K, O, A>,
+    w: &FiniteFunction<K>,
+) -> Option<(FiniteFunction<K>, FiniteFunction<K>)> {
+    Some(((&pattern.s >> w)?, (&pattern.t >> w)?))
+}
+
+pub(crate) fn is_smc_open_match<K: ArrayKind, O, A>(
+    pattern: &OpenHypergraph<K, O, A>,
+    host: &OpenHypergraph<K, O, A>,
+    w: &FiniteFunction<K>,
+) -> bool
+where
+    K::Type<K::I>: NaturalArray<K>,
+    K::Type<O>: Array<K, O>,
+    K::Type<A>: Array<K, A>,
+{
+    if !host.is_monogamous() || !host.is_acyclic() {
+        return false;
+    }
+
+    let Some((inputs_in_host, outputs_in_host)) = smc_boundary_images(pattern, w) else {
+        return false;
+    };
+
+    inputs_in_host.is_injective()
+        && outputs_in_host.is_injective()
+        && inputs_in_host.has_disjoint_image(&outputs_in_host)
+}
+
+pub fn find_subgraph_matches<K: ArrayKind, O, A>(
+    pattern: &OpenHypergraph<K, O, A>,
+    host: &OpenHypergraph<K, O, A>,
+    options: &MatchOptions,
+) -> Vec<OpenHypergraphMatch<K>>
+where
+    K::Type<K::I>: NaturalArray<K>,
+    K::Type<O>: Array<K, O> + PartialEq,
+    K::Type<A>: Array<K, A> + PartialEq,
+    O: PartialEq,
+    A: PartialEq,
+    K::I: Into<usize> + core::convert::TryFrom<usize>,
+    for<'a> K::Slice<'a, K::I>: From<&'a [K::I]>,
+{
+    find_hypergraph_subgraph_matches(&pattern.h, &host.h, options)
+        .into_iter()
+        .map(|HypergraphMatch { w, x }| OpenHypergraphMatch { w, x })
+        .collect()
+}
+
+pub fn find_smc_matches<K: ArrayKind, O, A>(
+    pattern: &OpenHypergraph<K, O, A>,
+    host: &OpenHypergraph<K, O, A>,
+    options: &MatchOptions,
+) -> Vec<OpenHypergraphMatch<K>>
+where
+    K::Type<K::I>: NaturalArray<K>,
+    K::Type<O>: Array<K, O> + PartialEq,
+    K::Type<A>: Array<K, A> + PartialEq,
+    O: PartialEq,
+    A: PartialEq,
+    K::I: Into<usize> + core::convert::TryFrom<usize>,
+    for<'a> K::Slice<'a, K::I>: From<&'a [K::I]>,
+{
+    find_subgraph_matches(pattern, host, options)
+        .into_iter()
+        .filter(|m| is_smc_open_match(pattern, host, &m.w))
+        .collect()
+}

--- a/src/strict/open_hypergraph/mod.rs
+++ b/src/strict/open_hypergraph/mod.rs
@@ -1,5 +1,6 @@
 //! The primary datastructure for representing cospans of hypergraphs
 mod arrow;
+pub mod matching;
 #[cfg(feature = "experimental")]
 mod rewrite;
 #[cfg(test)]
@@ -7,5 +8,6 @@ mod rewrite;
 mod rewrite_tests;
 
 pub use arrow::*;
+pub use matching::*;
 #[cfg(feature = "experimental")]
 pub use rewrite::*;

--- a/src/strict/open_hypergraph/mod.rs
+++ b/src/strict/open_hypergraph/mod.rs
@@ -1,5 +1,6 @@
 //! The primary datastructure for representing cospans of hypergraphs
 mod arrow;
+#[cfg(any(feature = "experimental", test))]
 pub mod matching;
 #[cfg(feature = "experimental")]
 mod rewrite;
@@ -8,6 +9,7 @@ mod rewrite;
 mod rewrite_tests;
 
 pub use arrow::*;
+#[cfg(any(feature = "experimental", test))]
 pub use matching::*;
 #[cfg(feature = "experimental")]
 pub use rewrite::*;

--- a/src/strict/open_hypergraph/rewrite.rs
+++ b/src/strict/open_hypergraph/rewrite.rs
@@ -1,8 +1,10 @@
 use crate::array::*;
 use crate::category::Arrow;
 use crate::finite_function::FiniteFunction;
+use crate::strict::hypergraph::matching::MatchOptions;
 use crate::strict::hypergraph::arrow::is_convex_subgraph_morphism;
 use crate::strict::hypergraph::Hypergraph;
+use crate::strict::open_hypergraph::matching::{find_smc_matches, is_smc_open_match};
 use crate::strict::open_hypergraph::OpenHypergraph;
 use num_traits::Zero;
 
@@ -112,7 +114,7 @@ impl<'a, K: ArrayKind, O, A> SmcRewriteMatch<'a, K, O, A> {
         K::Type<O>: Array<K, O> + PartialEq,
         K::Type<A>: Array<K, A> + PartialEq,
     {
-        if !host.is_monogamous() || !host.is_acyclic() {
+        if !is_smc_open_match(&rule.lhs, host, &w) {
             return None;
         }
         if is_convex_subgraph_morphism(&rule.lhs.h, &host.h, &w, &x) {
@@ -137,6 +139,46 @@ impl<'a, K: ArrayKind, O, A> SmcRewriteMatch<'a, K, O, A> {
     pub fn host(&self) -> &OpenHypergraph<K, O, A> {
         self.host
     }
+}
+
+pub fn find_smc_rewrite_matches<'a, K: ArrayKind, O, A>(
+    rule: &'a SmcRewriteRule<K, O, A>,
+    host: &'a OpenHypergraph<K, O, A>,
+    options: &MatchOptions,
+) -> Vec<SmcRewriteMatch<'a, K, O, A>>
+where
+    K::Type<K::I>: NaturalArray<K>,
+    K::Type<bool>: Array<K, bool>,
+    K::Type<O>: Array<K, O> + PartialEq,
+    K::Type<A>: Array<K, A> + PartialEq,
+    O: PartialEq,
+    A: PartialEq,
+    K::I: Into<usize> + core::convert::TryFrom<usize>,
+    for<'b> K::Slice<'b, K::I>: From<&'b [K::I]>,
+{
+    find_smc_matches(rule.lhs(), host, options)
+        .into_iter()
+        .filter_map(|m| SmcRewriteMatch::new(rule, host, m.w, m.x))
+        .collect()
+}
+
+pub fn find_first_smc_rewrite_match<'a, K: ArrayKind, O, A>(
+    rule: &'a SmcRewriteRule<K, O, A>,
+    host: &'a OpenHypergraph<K, O, A>,
+    mut options: MatchOptions,
+) -> Option<SmcRewriteMatch<'a, K, O, A>>
+where
+    K::Type<K::I>: NaturalArray<K>,
+    K::Type<bool>: Array<K, bool>,
+    K::Type<O>: Array<K, O> + PartialEq,
+    K::Type<A>: Array<K, A> + PartialEq,
+    O: PartialEq,
+    A: PartialEq,
+    K::I: Into<usize> + core::convert::TryFrom<usize>,
+    for<'b> K::Slice<'b, K::I>: From<&'b [K::I]>,
+{
+    options.stop_after_first = true;
+    find_smc_rewrite_matches(rule, host, &options).into_iter().next()
 }
 
 impl<'a, K: ArrayKind, O, A> Clone for SmcRewriteMatch<'a, K, O, A>

--- a/src/strict/open_hypergraph/rewrite.rs
+++ b/src/strict/open_hypergraph/rewrite.rs
@@ -1,8 +1,8 @@
 use crate::array::*;
 use crate::category::Arrow;
 use crate::finite_function::FiniteFunction;
-use crate::strict::hypergraph::matching::MatchOptions;
 use crate::strict::hypergraph::arrow::is_convex_subgraph_morphism;
+use crate::strict::hypergraph::matching::MatchOptions;
 use crate::strict::hypergraph::Hypergraph;
 use crate::strict::open_hypergraph::matching::{find_smc_matches, is_smc_open_match};
 use crate::strict::open_hypergraph::OpenHypergraph;
@@ -178,7 +178,9 @@ where
     for<'b> K::Slice<'b, K::I>: From<&'b [K::I]>,
 {
     options.stop_after_first = true;
-    find_smc_rewrite_matches(rule, host, &options).into_iter().next()
+    find_smc_rewrite_matches(rule, host, &options)
+        .into_iter()
+        .next()
 }
 
 impl<'a, K: ArrayKind, O, A> Clone for SmcRewriteMatch<'a, K, O, A>

--- a/src/strict/open_hypergraph/rewrite_tests.rs
+++ b/src/strict/open_hypergraph/rewrite_tests.rs
@@ -3,9 +3,10 @@ use crate::category::Arrow;
 use crate::finite_function::FiniteFunction;
 use crate::indexed_coproduct::IndexedCoproduct;
 use crate::semifinite::SemifiniteFunction;
+use crate::strict::hypergraph::matching::MatchOptions;
 use crate::strict::hypergraph::Hypergraph;
 use crate::strict::open_hypergraph::{
-    apply_smc_rewrite, OpenHypergraph, SmcRewriteMatch, SmcRewriteRule,
+    apply_smc_rewrite, find_smc_rewrite_matches, OpenHypergraph, SmcRewriteMatch, SmcRewriteRule,
 };
 use std::collections::HashMap;
 
@@ -1552,4 +1553,22 @@ fn smc_match_preserves_boundary_disjointness_for_valid_rule() {
     let lhs_inputs_in_host = (&r.lhs.graph.s >> m.w()).unwrap();
     let lhs_outputs_in_host = (&r.lhs.graph.t >> m.w()).unwrap();
     assert!(lhs_inputs_in_host.has_disjoint_image(&lhs_outputs_in_host));
+}
+
+#[test]
+fn smc_rewrite_match_search_finds_named_delete_match() {
+    let (rule, _lhs, _rhs) = delete_single_edge_rule_named(20);
+    let host = make_named_open_hypergraph(
+        [w("a", OBJ), w("b", OBJ), w("c", OBJ)],
+        [e("drop", ["a"], ["b"], 20), e("keep", ["b"], ["c"], 21)],
+        [inp("a")],
+        [out("c")],
+    );
+
+    let matches = find_smc_rewrite_matches(&rule, &host.graph, &MatchOptions::default());
+    assert_eq!(matches.len(), 1);
+
+    let m = &matches[0];
+    assert_eq!(m.x().table.0, vec![0]);
+    assert_eq!(m.w().table.0, vec![host.wire_ix["a"], host.wire_ix["b"]]);
 }

--- a/src/strict/tests/matching.rs
+++ b/src/strict/tests/matching.rs
@@ -58,7 +58,12 @@ fn strict_match_finds_expected_single_embedding() {
 
 #[test]
 fn strict_match_can_filter_nonconvex_embeddings() {
-    let pattern = make_hypergraph(&[vec![0], vec![1]], &[vec![1], vec![2]], vec![0, 0, 0], vec![1, 2]);
+    let pattern = make_hypergraph(
+        &[vec![0], vec![1]],
+        &[vec![1], vec![2]],
+        vec![0, 0, 0],
+        vec![1, 2],
+    );
     let host = make_hypergraph(
         &[vec![0], vec![1], vec![0]],
         &[vec![1], vec![2], vec![2]],

--- a/src/strict/tests/matching.rs
+++ b/src/strict/tests/matching.rs
@@ -109,7 +109,12 @@ fn strict_match_requires_mono_by_default_for_wire_maps() {
 
 #[test]
 fn strict_match_keeps_operation_maps_mono_when_wire_maps_are_relaxed() {
-    let pattern = make_hypergraph(&[vec![0], vec![0]], &[vec![0], vec![0]], vec![0], vec![7, 7]);
+    let pattern = make_hypergraph(
+        &[vec![0], vec![0]],
+        &[vec![0], vec![0]],
+        vec![0],
+        vec![7, 7],
+    );
     let host = make_hypergraph(&[vec![0]], &[vec![0]], vec![0], vec![7]);
 
     let default_matches = find_subgraph_matches(&pattern, &host, &MatchOptions::default());

--- a/src/strict/tests/matching.rs
+++ b/src/strict/tests/matching.rs
@@ -78,7 +78,7 @@ fn strict_match_can_filter_nonconvex_embeddings() {
         &pattern,
         &host,
         &MatchOptions {
-            mono: true,
+            non_mono_wires: Vec::new(),
             require_convex: true,
             stop_after_first: false,
         },
@@ -98,13 +98,29 @@ fn strict_match_requires_mono_by_default_for_wire_maps() {
         &pattern,
         &host,
         &MatchOptions {
-            mono: false,
+            non_mono_wires: vec![0, 1],
             ..MatchOptions::default()
         },
     );
     assert_eq!(relaxed_matches.len(), 1);
     assert_eq!(relaxed_matches[0].w.table.0, vec![0, 0]);
     assert!(relaxed_matches[0].x.table.0.is_empty());
+}
+
+#[test]
+fn strict_match_only_relaxes_listed_wires() {
+    let pattern = make_hypergraph(&[], &[], vec![0, 0], vec![]);
+    let host = make_hypergraph(&[], &[], vec![0], vec![]);
+
+    let relaxed_matches = find_subgraph_matches(
+        &pattern,
+        &host,
+        &MatchOptions {
+            non_mono_wires: vec![0],
+            ..MatchOptions::default()
+        },
+    );
+    assert!(relaxed_matches.is_empty());
 }
 
 #[test]
@@ -124,7 +140,7 @@ fn strict_match_keeps_operation_maps_mono_when_wire_maps_are_relaxed() {
         &pattern,
         &host,
         &MatchOptions {
-            mono: false,
+            non_mono_wires: vec![0],
             ..MatchOptions::default()
         },
     );

--- a/src/strict/tests/matching.rs
+++ b/src/strict/tests/matching.rs
@@ -78,9 +78,50 @@ fn strict_match_can_filter_nonconvex_embeddings() {
         &pattern,
         &host,
         &MatchOptions {
+            mono: true,
             require_convex: true,
             stop_after_first: false,
         },
     );
     assert!(convex_only.is_empty());
+}
+
+#[test]
+fn strict_match_requires_mono_by_default_for_wire_maps() {
+    let pattern = make_hypergraph(&[], &[], vec![0, 0], vec![]);
+    let host = make_hypergraph(&[], &[], vec![0], vec![]);
+
+    let default_matches = find_subgraph_matches(&pattern, &host, &MatchOptions::default());
+    assert!(default_matches.is_empty());
+
+    let relaxed_matches = find_subgraph_matches(
+        &pattern,
+        &host,
+        &MatchOptions {
+            mono: false,
+            ..MatchOptions::default()
+        },
+    );
+    assert_eq!(relaxed_matches.len(), 1);
+    assert_eq!(relaxed_matches[0].w.table.0, vec![0, 0]);
+    assert!(relaxed_matches[0].x.table.0.is_empty());
+}
+
+#[test]
+fn strict_match_keeps_operation_maps_mono_when_wire_maps_are_relaxed() {
+    let pattern = make_hypergraph(&[vec![0], vec![0]], &[vec![0], vec![0]], vec![0], vec![7, 7]);
+    let host = make_hypergraph(&[vec![0]], &[vec![0]], vec![0], vec![7]);
+
+    let default_matches = find_subgraph_matches(&pattern, &host, &MatchOptions::default());
+    assert!(default_matches.is_empty());
+
+    let relaxed_matches = find_subgraph_matches(
+        &pattern,
+        &host,
+        &MatchOptions {
+            mono: false,
+            ..MatchOptions::default()
+        },
+    );
+    assert!(relaxed_matches.is_empty());
 }

--- a/src/strict/tests/matching.rs
+++ b/src/strict/tests/matching.rs
@@ -1,0 +1,81 @@
+use crate::array::vec::VecKind;
+use crate::strict::hypergraph::matching::{find_subgraph_matches, MatchOptions};
+use crate::strict::Hypergraph;
+
+fn make_hypergraph(
+    sources: &[Vec<usize>],
+    targets: &[Vec<usize>],
+    w_labels: Vec<i32>,
+    x_labels: Vec<i32>,
+) -> Hypergraph<VecKind, i32, i32> {
+    use crate::array::vec::VecArray;
+    use crate::finite_function::FiniteFunction;
+    use crate::indexed_coproduct::IndexedCoproduct;
+    use crate::semifinite::SemifiniteFunction;
+
+    let mut lengths = Vec::with_capacity(sources.len());
+    let mut source_values = Vec::new();
+    for segment in sources {
+        lengths.push(segment.len());
+        source_values.extend_from_slice(segment);
+    }
+
+    let source_sizes = SemifiniteFunction::new(VecArray(lengths.clone()));
+    let source_values = FiniteFunction::new(VecArray(source_values), w_labels.len()).unwrap();
+    let s = IndexedCoproduct::from_semifinite(source_sizes, source_values).unwrap();
+
+    let mut target_lengths = Vec::with_capacity(targets.len());
+    let mut target_values = Vec::new();
+    for segment in targets {
+        target_lengths.push(segment.len());
+        target_values.extend_from_slice(segment);
+    }
+
+    let target_sizes = SemifiniteFunction::new(VecArray(target_lengths));
+    let target_values = FiniteFunction::new(VecArray(target_values), w_labels.len()).unwrap();
+    let t = IndexedCoproduct::from_semifinite(target_sizes, target_values).unwrap();
+
+    let w = SemifiniteFunction::new(VecArray(w_labels));
+    let x = SemifiniteFunction::new(VecArray(x_labels));
+    Hypergraph::new(s, t, w, x).unwrap()
+}
+
+#[test]
+fn strict_match_finds_expected_single_embedding() {
+    let pattern = make_hypergraph(&[vec![0]], &[vec![1]], vec![0, 0], vec![7]);
+    let host = make_hypergraph(
+        &[vec![0], vec![1]],
+        &[vec![1], vec![2]],
+        vec![0, 0, 0],
+        vec![7, 8],
+    );
+
+    let matches = find_subgraph_matches(&pattern, &host, &MatchOptions::default());
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].x.table.0, vec![0]);
+    assert_eq!(matches[0].w.table.0, vec![0, 1]);
+}
+
+#[test]
+fn strict_match_can_filter_nonconvex_embeddings() {
+    let pattern = make_hypergraph(&[vec![0], vec![1]], &[vec![1], vec![2]], vec![0, 0, 0], vec![1, 2]);
+    let host = make_hypergraph(
+        &[vec![0], vec![1], vec![0]],
+        &[vec![1], vec![2], vec![2]],
+        vec![0, 0, 0],
+        vec![1, 2, 3],
+    );
+
+    let plain = find_subgraph_matches(&pattern, &host, &MatchOptions::default());
+    assert_eq!(plain.len(), 1);
+
+    let convex_only = find_subgraph_matches(
+        &pattern,
+        &host,
+        &MatchOptions {
+            require_convex: true,
+            stop_after_first: false,
+        },
+    );
+    assert!(convex_only.is_empty());
+}

--- a/src/strict/tests/mod.rs
+++ b/src/strict/tests/mod.rs
@@ -1,2 +1,3 @@
 pub mod graph;
 pub mod layer;
+pub mod matching;


### PR DESCRIPTION
## Context

Simple implementation of Ullmann V2 for searching matches in strict open hypergraphs.

## Details

We search for matches using Ullmann. We can relax the search allowing non mono for LHS interfaces (still mono on boxes and other wires). In theory, Ullmann might be less efficient in pruning the search space in this case (they say that CSP approach is better), but perhaps it is a good compromise for now since patterns are small and we still keep mono almost everywhere but LHS interface.

this PR will deprecate https://github.com/hellas-ai/open-hypergraphs/pull/22
